### PR TITLE
Fix for Font Awesome CDN's auto accessibility

### DIFF
--- a/less/material-cards-auto-height.less
+++ b/less/material-cards-auto-height.less
@@ -122,19 +122,19 @@
             line-height: 52px;
             text-decoration: none;
             top: 200px;
-            &:nth-child(1) {
+            &:nth-of-type(1) {
                 .mc-transtition (.5s)
             }
-            &:nth-child(2) {
+            &:nth-of-type(2) {
                 .mc-transtition (.6s)
             }
-            &:nth-child(3) {
+            &:nth-of-type(3) {
                 .mc-transtition (.7s)
             }
-            &:nth-child(4) {
+            &:nth-of-type(4) {
                 .mc-transtition (.8s)
             }
-            &:nth-child(5) {
+            &:nth-of-type(5) {
                 .mc-transtition (.9s)
             }
         }

--- a/less/material-cards.less
+++ b/less/material-cards.less
@@ -122,19 +122,19 @@
             line-height: 52px;
             text-decoration: none;
             top: 200px;
-            &:nth-child(1) {
+            &:nth-of-type(1) {
                 .mc-transtition (.5s)
             }
-            &:nth-child(2) {
+            &:nth-of-type(2) {
                 .mc-transtition (.6s)
             }
-            &:nth-child(3) {
+            &:nth-of-type(3) {
                 .mc-transtition (.7s)
             }
-            &:nth-child(4) {
+            &:nth-of-type(4) {
                 .mc-transtition (.8s)
             }
-            &:nth-child(5) {
+            &:nth-of-type(5) {
                 .mc-transtition (.9s)
             }
         }


### PR DESCRIPTION
When [Font Awesome](http://fontawesome.io/accessibility/) auto-generates `<span class="sr-only"></span>` elements
for the social icons in the footer, the `nth-child` CSS selectors fail to
pick up the anchor elements as intended (they skip a number due to the
wedged `<span>`).
This commit fixes this behaviour by using the `nth-of-type` CSS selector
instead.
